### PR TITLE
don't exclude cookies from request headers when importing from curl

### DIFF
--- a/packages/bruno-app/src/utils/curl/parse-curl.js
+++ b/packages/bruno-app/src/utils/curl/parse-curl.js
@@ -72,11 +72,10 @@ const parseCurlCommand = (curlCommand) => {
     parsedArguments.header.forEach((header) => {
       if (header.indexOf('Cookie') !== -1) {
         cookieString = header;
-      } else {
-        const components = header.split(/:(.*)/);
-        if (components[1]) {
-          headers[components[0]] = components[1].trim();
-        }
+      }
+      const components = header.split(/:(.*)/);
+      if (components[1]) {
+        headers[components[0]] = components[1].trim();
       }
     });
   }


### PR DESCRIPTION
The cookie header was intentionally skipped when importing curl commands 
