### PR TITLE
fix: Multipart-form file path provided was incomplete and needs collection path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ yarn-error.log*
 #dev editor
 bruno.iml
 .idea
+.vscode

--- a/packages/bruno-core/src/request/preRequest/createHttpRequest.ts
+++ b/packages/bruno-core/src/request/preRequest/createHttpRequest.ts
@@ -87,6 +87,7 @@ async function getRequestBody(context: RequestContext): Promise<[string | Buffer
   let extraHeaders: Record<string, string> = {};
 
   const body = context.requestItem.request.body;
+  const collectionPath = context.collection.pathname;
   switch (body.mode) {
     case 'multipartForm':
       const formData = new FormData();
@@ -99,7 +100,7 @@ async function getRequestBody(context: RequestContext): Promise<[string | Buffer
             formData.append(item.name, item.value);
             break;
           case 'file':
-            const fileData = await fs.readFile(item.value[0]!);
+            const fileData = await fs.readFile(collectionPath + "/" + item.value[0]!);
             formData.append(item.name, fileData, path.basename(item.value[0]!));
             break;
         }


### PR DESCRIPTION
# Description

When testing out and adding files using the Multipart Form using the new request meth, I noticed that the path used is relative to the collection and does not work with the fs/promises module that expects an absolute filepath. Since it looks like the frontend is sending filepaths based on where the collection is opened, I figured fetching it from the context should work just fine.

On top of that a little addition to the .gitignore file since I opened the project in VS Code, if that is ok :)

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
